### PR TITLE
Bump to fourmolu-0.7.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Fourmolu action v2
+
+* Uses Fourmolu 0.7.0.1.
+
 ## Fourmolu action v1
 
 * Uses Fourmolu 0.6.0.0.

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,7 +20,7 @@ const tool_cache = __webpack_require__(7784);
 const exec = __webpack_require__(1514);
 const glob = __webpack_require__(8090);
 
-const fourmolu_version = '0.6.0.0';
+const fourmolu_version = '0.7.0.1';
 
 // XXX: These release binaries appear to be dynamically linked, so they may not
 // run on some systems.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const tool_cache = require('@actions/tool-cache');
 const exec = require('@actions/exec');
 const glob = require('@actions/glob');
 
-const fourmolu_version = '0.6.0.0';
+const fourmolu_version = '0.7.0.1';
 
 // XXX: These release binaries appear to be dynamically linked, so they may not
 // run on some systems.


### PR DESCRIPTION
This bumps to the newest fourmolu release: 0.7.0.1

https://github.com/fourmolu/fourmolu/releases/tag/v0.7.0.1
