### PR TITLE
Add a full example yaml file to the README for easy copy-pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ versions available.  Each version of the Fourmolu Action generally has a
 corresponding version of `fourmolu`.  Make sure you pick a Fourmolu Action
 version that uses the version of `fourmolu` you use locally.
 
-## Full Example
+### Full Example
 
 Here's a full YAML file you can copy and paste into your repo that runs
 `fourmolu-action`.  Add this as a file like `.github/workflows/fourmolu.yaml`.
@@ -41,7 +41,7 @@ jobs:
       - uses: fourmolu/fourmolu-action@v1
 ```
 
-## Example with more Options
+### Example with more Options
 
 Here's a more complicated example that shows more options being used:
 
@@ -59,7 +59,7 @@ Here's a more complicated example that shows more options being used:
     extra-args: "--indent-wheres true"
 ```
 
-## Example Usage with Build Matrix
+### Example Usage with Build Matrix
 
 If you are using a build matrix, then it is more efficient to have a
 separate job for checking of formatting:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ versions available.  Each version of the Fourmolu Action generally has a
 corresponding version of `fourmolu`.  Make sure you pick a Fourmolu Action
 version that uses the version of `fourmolu` you use locally.
 
+## Full Example
+
+Here's a full YAML file you can copy and paste into your repo that runs
+`fourmolu-action`.  Add this as a file like `.github/workflows/fourmolu.yaml`.
+This Workflow will run everytime you push to a branch.
+
+```yaml
+name: fourmolu
+on: push
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      # Note that you must checkout your code before running fourmolu/fourmolu-action
+      - uses: actions/checkout@v2
+      - uses: fourmolu/fourmolu-action@v1
+```
+
+## Example with more Options
+
 Here's a more complicated example that shows more options being used:
 
 ```yaml
@@ -65,6 +85,9 @@ passes.
 The available options are defined in [`./action.yml`](./action.yml).  See that
 file for more explanation.
 
+<!-- fourmolu-action currently doesn't support running on Windows. -->
+<!--
+
 ## Windows
 
 If you are running a workflow on Windows, be wary of [Git's
@@ -75,6 +98,8 @@ disable `core.autocrlf`:
 ```shell
 $ git config --global core.autocrlf false
 ```
+
+-->
 
 ## Hacking on this repo
 


### PR DESCRIPTION
This PR adds a full example YAML file to the README so end-users can easily copy-paste it to get something working.  It also adds a note that you need to checkout your code before running `fourmolu-action`.

Closes #4 