### PR TITLE
bump to fourmolu-0.9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Fourmolu action v5
+
+* Uses Fourmolu 0.9.0.0.
+
 ## Fourmolu action v4
 
 * Uses Fourmolu 0.8.2.0.

--- a/README.md
+++ b/README.md
@@ -149,10 +149,13 @@ v3	Latest	v3	2022-08-09T15:11:02Z
 ```
 
 The most recent release in this case is `v3`, so if you want to make a new
-release, just bump the version by one:
+release, just bump the version by one to `v4`:
 
 ```console
-$ gh release create --notes "This release uses fourmolu-0.9.0.0." --title "v4" v4
+$ vim ./CHANGELOG.md   # add an entry for this new v4 release
+$ git commit -m 'bumping to v4 with fourmolu-0.9.0.0'  # create a commit for the new changelog
+$ git push  # push the changelog commit to the remote master branch
+$ gh release create --notes "This release uses fourmolu-0.9.0.0." --title "v4" v4  # make a Release on GitHub
 ```
 
 You may then want to run `git fetch` to fetch the new tag that has been

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,7 +20,7 @@ const tool_cache = __webpack_require__(7784);
 const exec = __webpack_require__(1514);
 const glob = __webpack_require__(8090);
 
-const fourmolu_version = '0.8.2.0';
+const fourmolu_version = '0.9.0.0';
 
 // XXX: These release binaries appear to be dynamically linked, so they may not
 // run on some systems.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const tool_cache = require('@actions/tool-cache');
 const exec = require('@actions/exec');
 const glob = require('@actions/glob');
 
-const fourmolu_version = '0.8.2.0';
+const fourmolu_version = '0.9.0.0';
 
 // XXX: These release binaries appear to be dynamically linked, so they may not
 // run on some systems.


### PR DESCRIPTION
Bump the fourmolu version to 0.9.0.0 and prepare for the v5 release:

https://github.com/fourmolu/fourmolu/releases/tag/v0.9.0.0
