### PR TITLE
Bump node version to remove node12 deprecation warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     description: >
       Extra arguments to pass to Fourmolu.
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub is phasing out node12 as mentioned here: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Luckily, just changing the node version is enough for this project :).