### PR TITLE
Change fourmolu-action version from v1 to v6 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and its formatted version.
 In the simple case all you need to do is to add this step to your job:
 
 ```yaml
-- uses: fourmolu/fourmolu-action@v1
+- uses: fourmolu/fourmolu-action@v6
 ```
 
 The `@v1` after `fourmolu-action` should be replaced with the version of the
@@ -38,7 +38,7 @@ jobs:
     steps:
       # Note that you must checkout your code before running fourmolu/fourmolu-action
       - uses: actions/checkout@v2
-      - uses: fourmolu/fourmolu-action@v1
+      - uses: fourmolu/fourmolu-action@v6
 ```
 
 ### Example with more Options
@@ -46,7 +46,7 @@ jobs:
 Here's a more complicated example that shows more options being used:
 
 ```yaml
-- uses: fourmolu/fourmolu-action@v1
+- uses: fourmolu/fourmolu-action@v6
   with:
     # Only check the format of .hs in the src/ directory.
     pattern: |
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: fourmolu/fourmolu-action@v1
+      - uses: fourmolu/fourmolu-action@v6
   build:
     runs-on: ubuntu-latest
     needs: fourmolu

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In the simple case all you need to do is to add this step to your job:
 - uses: fourmolu/fourmolu-action@v6
 ```
 
-The `@v1` after `fourmolu-action` should be replaced with the version of the
+The `@v6` after `fourmolu-action` should be replaced with the version of the
 Fourmolu Action you want to use.  See
 [Releases](https://github.com/fourmolu/fourmolu-action/releases) for all
 versions available.  Each version of the Fourmolu Action generally has a


### PR DESCRIPTION
Thanks a lot for working on `fourmolu` and `fourmolu-action`! I recently switched to `fourmolu` in one of my personal projects and it worked like a charm 🤗 

I used this action on GitHub Actions CI as well and it (almost) worked immediately. The problem was that I copied the usage example from `README.md` and my project uses custom `fourmolu.yaml`. However, my `fourmolu` CI check failed immediately.

I checked the latest version in this repository and noticed that it's far greater than `v1` (it's actually `v6`). After upgrading, everything worked like a charm ✨ 

So I assumed, earlier versions of `fourmolu` didn't support custom user config. I believe it would be helpful to bump up the version in `README.md` (even if it'll become outdated again) to reduce the frustration of potential users.