### PR TITLE
Use actions/checkout@v3 instead of deprecatedactions/checkout@v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,5 +22,5 @@ jobs:
       - name: Disable core.autocrlf on Windows
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Note that you must checkout your code before running haskell-actions/run-fourmolu
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: haskell-actions/run-fourmolu@v9
         with:
           version: "0.13.0.0"
@@ -96,7 +96,7 @@ jobs:
   fourmolu:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: haskell-actions/run-fourmolu@v9
         with:
           version: "0.13.0.0"


### PR DESCRIPTION
Fixes #22 
Replaces `actions/checkout@v2` by `actions/checkout@v3` in the snippets in the README.md and in the workflow file of this repository.