### PR TITLE
Upgrade from Node.js 20 to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ inputs:
       Defaults to the repository root if not set.
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub is deprecating Node.js 20 actions. Starting June 2, 2026, actions will be forced to run on Node.js 24.

This PR updates `action.yml` from `node20` to `node24` to avoid the deprecation warning and ensure compatibility.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/